### PR TITLE
Fixes repository link (colors -> color)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.5.0"
 authors = ["Arturo Castro", "Brendan Zabarauskas <bjzaba@yahoo.com.au>", "Luqman Aden"]
 description = "A library that provides types and conversions for working with various color formats. Forked from the unmuntained crate color"
 license-file="LICENSE"
-repository="https://github.com/arturoc/colors-rs"
+repository="https://github.com/arturoc/color-rs"
 
 [lib]
 name="color"


### PR DESCRIPTION
There doesn't seem to be a way to get the GitHub editor *not* to add a newline to the end of the file, so this also inadvertently does that.