### PR TITLE
qualify self.clamp to avoid multiple applicable items in scope

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -244,7 +244,7 @@ impl Channel for f64 {
 pub trait FloatChannel: Float + Channel {
     #[inline]
     fn saturate(self) -> Self {
-        self.clamp(zero(),one())
+        Channel::clamp(self, zero(), one())
     }
 }
 


### PR DESCRIPTION
fix this error
```rust
error[E0034]: multiple applicable items in scope
    --> /home/mirsella/.local/share/cargo/registry/src/index.crates.io-6f17d22bba15001f/color-rs-0.8.0/src/channel.rs:247:14
     |
247  |         self.clamp(zero(),one())
     |              ^^^^^ multiple `clamp` found
     |
note: candidate #1 is defined in the trait `num_traits::Float`
    --> /home/mirsella/.local/share/cargo/registry/src/index.crates.io-6f17d22bba15001f/num-traits-0.2.19/src/float.rs:1545:5
     |
1545 |     fn clamp(self, min: Self, max: Self) -> Self {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: candidate #2 is defined in the trait `Channel`
    --> /home/mirsella/.local/share/cargo/registry/src/index.crates.io-6f17d22bba15001f/color-rs-0.8.0/src/channel.rs:38:5
     |
38   |     fn clamp(self, lo: Self, hi: Self) -> Self {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
help: disambiguate the method for candidate #1
     |
247  |         num_traits::Float::clamp(self, zero(), one())
     |
help: disambiguate the method for candidate #2
     |
247  |         Channel::clamp(self, zero(), one())
     |
```